### PR TITLE
Fix secret page navigation links

### DIFF
--- a/src/components/About.tsx
+++ b/src/components/About.tsx
@@ -1,5 +1,6 @@
 import { motion } from "framer-motion";
 import GlassCard from "./GlassCard";
+import Link from "next/link";
 
 export default function About() {
   return (
@@ -23,31 +24,31 @@ export default function About() {
         </p>
 
         <div className="mt-6 flex flex-wrap gap-3">
-          <a
-            href="#projects"
+          <Link
+            href="/#projects"
             className="inline-flex items-center gap-2 rounded-lg bg-[var(--accent)] text-darkBlue font-semibold px-4 py-2 hover:brightness-110 focus:outline-none focus:ring-2 focus:ring-[var(--accent)] transition"
           >
             View Projects
             <span aria-hidden>↘</span>
-          </a>
-          <a
-            href="#experience"
+          </Link>
+          <Link
+            href="/#experience"
             className="inline-flex items-center gap-2 rounded-lg border border-[var(--accent-weak)] text-[var(--accent)] px-4 py-2 hover:bg-[var(--accent-bg-weak)] backdrop-blur-sm transition"
           >
             Experience
-          </a>
+          </Link>
         </div>
 
         <GlassCard className="p-4 mt-8">
           <p className="text-sm text-slate-600 dark:text-grayTone">
             Currently exploring AI-assisted DeFi agents and mobile apps.
             Interested in collaborating or learning more?{" "}
-            <a
-              href="#contact"
+            <Link
+              href="/#contact"
               className="text-[var(--accent)] underline hover:brightness-110 transition"
             >
               Let&apos;s connect!
-            </a>
+            </Link>
           </p>
         </GlassCard>
       </div>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,11 +5,14 @@ import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import ThemeToggle from "./ThemeToggle";
 import { siteConfig } from "@/config/site";
 import { useActiveSection } from "@/hooks/useActiveSection";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 export default function Header() {
   const [isOpen, setIsOpen] = useState(false);
   const shouldReduceMotion = useReducedMotion();
   const { activeId } = useActiveSection();
+  const pathname = usePathname();
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
@@ -53,8 +56,8 @@ export default function Header() {
                 const isActive = activeId === item.id;
                 return (
                   <li className="w-full" key={item.id}>
-                    <a
-                      href={item.href}
+                    <Link
+                      href={pathname === "/" ? item.href : `/${item.href}`}
                       aria-current={isActive ? "page" : undefined}
                       className={`block w-full p-3 text-center rounded-md transition ${
                         isActive
@@ -64,7 +67,7 @@ export default function Header() {
                       onClick={() => setIsOpen(false)}
                     >
                       {item.label}
-                    </a>
+                    </Link>
                   </li>
                 );
               })}
@@ -88,8 +91,8 @@ export default function Header() {
                     const isActive = activeId === item.id;
                     return (
                       <li className="w-full" key={item.id}>
-                        <a
-                          href={item.href}
+                        <Link
+                          href={pathname === "/" ? item.href : `/${item.href}`}
                           aria-current={isActive ? "page" : undefined}
                           className={`block w-full p-3 text-center rounded-md transition ${
                             isActive
@@ -99,7 +102,7 @@ export default function Header() {
                           onClick={() => setIsOpen(false)}
                         >
                           {item.label}
-                        </a>
+                        </Link>
                       </li>
                     );
                   })}

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -5,9 +5,12 @@ import { motion } from "framer-motion";
 import ThemeToggle from "./ThemeToggle";
 import { siteConfig } from "@/config/site";
 import { useActiveSection } from "@/hooks/useActiveSection";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
 
 export default function Menu() {
   const { activeId } = useActiveSection();
+  const pathname = usePathname();
   const items = [
     { href: "#about", label: "About", id: "about" },
     { href: "#experience", label: "Experience", id: "experience" },
@@ -29,8 +32,8 @@ export default function Menu() {
               const isActive = activeId === item.id;
               return (
                 <motion.li key={item.href} initial={{ opacity: 0.7 }} whileHover={{ opacity: 1, x: 4 }} transition={{ duration: 0.2 }}>
-                  <a
-                    href={item.href}
+                  <Link
+                    href={pathname === "/" ? item.href : `/${item.href}`}
                     aria-current={isActive ? "page" : undefined}
                     className={`group inline-flex items-center gap-2 transition-colors ${
                       isActive
@@ -44,7 +47,7 @@ export default function Menu() {
                       }`}
                     />
                     {item.label}
-                  </a>
+                  </Link>
                 </motion.li>
               );
             })}


### PR DESCRIPTION
Convert internal hash links to absolute paths and `next/link` to fix navigation from non-root pages like `/secret`.

---
<a href="https://cursor.com/background-agent?bcId=bc-7ecfadba-6f73-4412-882e-37faea18bb4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7ecfadba-6f73-4412-882e-37faea18bb4e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

