### PR TITLE
Add instagram to get in touch section

### DIFF
--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -14,6 +14,15 @@ export default function Contact() {
       </p>
       <div className="mt-6 flex flex-wrap items-center gap-3">
         <a
+          href={siteConfig.links.github}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-2 rounded-md border border-black/10 dark:border-white/10 px-4 py-2 text-slate-600 dark:text-grayTone hover:text-[var(--accent)] hover:border-[var(--accent)] transition"
+        >
+          <FaGithub />
+          GitHub
+        </a>
+        <a
           href={siteConfig.links.linkedin}
           target="_blank"
           rel="noopener noreferrer"
@@ -39,15 +48,6 @@ export default function Contact() {
         >
           <FaInstagram />
           Instagram
-        </a>
-        <a
-          href={siteConfig.links.github}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-2 rounded-md border border-black/10 dark:border-white/10 px-4 py-2 text-slate-600 dark:text-grayTone hover:text-[var(--accent)] hover:border-[var(--accent)] transition"
-        >
-          <FaGithub />
-          GitHub
         </a>
       </div>
     </section>


### PR DESCRIPTION
Add Instagram to the "Get in touch" section and centralize social links using `siteConfig`.

---
<a href="https://cursor.com/background-agent?bcId=bc-0bfc16e3-7b17-4013-bc45-5b4532b2fce4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0bfc16e3-7b17-4013-bc45-5b4532b2fce4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

