### PR TITLE
fix: track mobile nav clicks in GA

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -7,6 +7,7 @@ import { siteConfig } from "@/config/site";
 import { useActiveSection } from "@/hooks/useActiveSection";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { trackNavigation } from "@/utils/analytics";
 
 export default function Header() {
   const [isOpen, setIsOpen] = useState(false);
@@ -65,7 +66,10 @@ export default function Header() {
                           ? "text-[var(--accent)] bg-[var(--accent-bg-weak)] border-2 border-[var(--accent-weak)]"
                           : "text-slate-600 dark:text-grayTone hover:text-[var(--accent)] hover:bg-black/5 dark:hover:bg-white/5 border-2 border-transparent hover:border-[var(--accent-weak)]"
                       }`}
-                      onClick={() => setIsOpen(false)}
+                      onClick={() => {
+                        trackNavigation(item.id);
+                        setIsOpen(false);
+                      }}
                     >
                       {item.label}
                     </Link>
@@ -106,7 +110,10 @@ export default function Header() {
                               ? "text-[var(--accent)] bg-[var(--accent-bg-weak)] border-2 border-[var(--accent-weak)]"
                               : "text-slate-600 dark:text-grayTone hover:text-[var(--accent)] hover:bg-black/5 dark:hover:bg-white/5 border-2 border-transparent hover:border-[var(--accent-weak)]"
                           }`}
-                          onClick={() => setIsOpen(false)}
+                          onClick={() => {
+                            trackNavigation(item.id);
+                            setIsOpen(false);
+                          }}
                         >
                           {item.label}
                         </Link>


### PR DESCRIPTION
## Summary
- Fix mobile nav analytics bug: `Header.tsx` (mobile menu) was missing `trackNavigation()` calls while `Menu.tsx` (desktop) was tracking them. Mobile nav clicks were invisible in GA.
- Add `trackNavigation(item.id)` to both mobile `Link` `onClick` handlers (reduced-motion and animated branches), mirroring the desktop menu.

## Changes
- `src/components/Header.tsx`: import `trackNavigation` and call it from both mobile nav `onClick` handlers before `setIsOpen(false)`.

## Verification
- `yarn lint`: passes (0 errors; 1 unrelated pre-existing warning in `ContactForm.tsx`)
- `yarn type-check`: no new errors related to this change (pre-existing `resend` module error in `contact.ts` is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)