### PR TITLE
fix: collapse dead identical ternary in Project type badge

### DIFF
--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -52,11 +52,7 @@ export const Project: FC<ProjectData> = ({
             <div className="absolute inset-0 bg-gradient-to-t from-black/20 to-transparent opacity-0 group-hover:opacity-100 transition-opacity duration-300" />
           </div>
           <span
-            className={`inline-block px-3 py-1.5 text-xs sm:text-sm font-semibold rounded-full border mt-3 transition-all duration-300 ${
-              projectType === "personal"
-                ? "border-[var(--accent-weak)] text-[var(--accent)] bg-transparent hover:bg-[var(--accent-bg-weak)] hover:border-[var(--accent)]"
-                : "border-[var(--accent-weak)] text-[var(--accent)] bg-transparent hover:bg-[var(--accent-bg-weak)] hover:border-[var(--accent)]"
-            }`}
+            className="inline-block px-3 py-1.5 text-xs sm:text-sm font-semibold rounded-full border mt-3 transition-all duration-300 border-[var(--accent-weak)] text-[var(--accent)] bg-transparent hover:bg-[var(--accent-bg-weak)] hover:border-[var(--accent)]"
             aria-label={`Project type: ${
               projectType === "personal" ? "Personal Project" : "Work Project"
             }`}


### PR DESCRIPTION
Both branches of the `projectType === "personal" ? ... : ...` className ternary in `src/components/Project.tsx` (lines 55–58) returned the same string. The condition had no effect, so the ternary is dead code.

Drop the ternary and keep a single class string. Net change: −5 / +1.

The label logic ("Personal Project" / "Work Project") still differs between types, so it stays inline (aria-label and content). Extracting it into a shared helper across files would be a larger refactor and out of scope for this cleanup.

Verified:
- `yarn test src/components/Project.test.tsx` → 3/3 passing
- `yarn lint src/components/Project.tsx` → clean
- `yarn type-check` → no new errors (one pre-existing `resend` module error in `src/app/actions/contact.ts` is unrelated and present on `main`)