### PR TITLE
refactor: centralize nav items (Header/Menu/useActiveSection)

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,7 @@
 import React, { useEffect, useState } from "react";
 import { motion, AnimatePresence, useReducedMotion } from "framer-motion";
 import ThemeToggle from "./ThemeToggle";
-import { siteConfig } from "@/config/site";
+import { siteConfig, navItems } from "@/config/site";
 import { useActiveSection } from "@/hooks/useActiveSection";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -22,14 +22,6 @@ export default function Header() {
     if (isOpen) document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
   }, [isOpen]);
-
-  const items = [
-    { href: "#about", label: "About", id: "about" },
-    { href: "#experience", label: "Experience", id: "experience" },
-    { href: "#projects", label: "Projects", id: "projects" },
-    { href: "#advisory", label: "Advisory", id: "advisory" },
-    { href: "#contact", label: "Contact", id: "contact" },
-  ];
 
   return (
     <header className="md:hidden sticky top-0 z-50 bg-white/90 dark:bg-darkBlue/90 backdrop-blur-md border-b border-slate-200 dark:border-white/5 shadow-sm">
@@ -54,7 +46,7 @@ export default function Header() {
           <nav id="mobile-menu" className="px-2 pb-4 relative bg-white/95 dark:bg-darkBlue/95 backdrop-blur-md">
             <div className="pointer-events-none absolute inset-x-0 -top-px h-px bg-gradient-to-r from-transparent via-[var(--accent)]/30 to-transparent" />
             <ul className="flex flex-col items-stretch gap-2 pt-2">
-              {items.map((item) => {
+              {navItems.map((item) => {
                 const isActive = activeId === item.id;
                 return (
                   <li className="w-full" key={item.id}>
@@ -92,7 +84,7 @@ export default function Header() {
               >
                 <div className="pointer-events-none absolute inset-x-0 -top-px h-px bg-gradient-to-r from-transparent via-[var(--accent)]/30 to-transparent" />
                 <ul className="flex flex-col items-stretch gap-2 pt-2">
-                  {items.map((item, index) => {
+                  {navItems.map((item, index) => {
                     const isActive = activeId === item.id;
                     return (
                       <motion.li

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -3,7 +3,7 @@
 import { FaGithub, FaInstagram, FaLinkedin, FaTwitter } from "react-icons/fa";
 import { motion } from "framer-motion";
 import ThemeToggle from "./ThemeToggle";
-import { siteConfig } from "@/config/site";
+import { siteConfig, navItems } from "@/config/site";
 import { useActiveSection } from "@/hooks/useActiveSection";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -12,13 +12,6 @@ import { trackNavigation, trackSocialLink } from "@/utils/analytics";
 export default function Menu() {
   const { activeId } = useActiveSection();
   const pathname = usePathname();
-  const items = [
-    { href: "#about", label: "About", id: "about" },
-    { href: "#experience", label: "Experience", id: "experience" },
-    { href: "#projects", label: "Projects", id: "projects" },
-    { href: "#advisory", label: "Advisory", id: "advisory" },
-    { href: "#contact", label: "Contact", id: "contact" },
-  ];
 
   return (
     <div className="flex flex-col h-full justify-between">
@@ -30,7 +23,7 @@ export default function Menu() {
         </div>
         <nav aria-label="Primary">
           <ul className="space-y-3">
-            {items.map((item) => {
+            {navItems.map((item) => {
               const isActive = activeId === item.id;
               return (
                 <motion.li key={item.href} initial={{ opacity: 0.7 }} whileHover={{ opacity: 1, x: 4 }} transition={{ duration: 0.2 }}>

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -3,6 +3,19 @@ export const ogImageSize = {
   height: 630,
 };
 
+// Single source of truth for the section nav (used by Header, Menu, useActiveSection).
+export const navItems = [
+  { href: "#about", label: "About", id: "about" },
+  { href: "#experience", label: "Experience", id: "experience" },
+  { href: "#projects", label: "Projects", id: "projects" },
+  { href: "#advisory", label: "Advisory", id: "advisory" },
+  { href: "#contact", label: "Contact", id: "contact" },
+] as const;
+
+export type NavItem = typeof navItems[number];
+export type SectionId = NavItem["id"];
+export const DEFAULT_SECTIONS: readonly SectionId[] = navItems.map((item) => item.id);
+
 export const siteConfig = {
   name: "Marc‑Aurele Besner",
   role: "Web3 Full‑Stack Engineer",

--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -1,9 +1,10 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
+import { DEFAULT_SECTIONS, type SectionId } from "@/config/site";
 
-const DEFAULT_SECTIONS = ["about", "experience", "projects", "advisory", "contact"] as const;
-export type SectionId = typeof DEFAULT_SECTIONS[number];
+// Re-exported for backward compatibility — SectionId lives in @/config/site now.
+export type { SectionId };
 
 export function useActiveSection(sectionIds: readonly string[] = DEFAULT_SECTIONS) {
   const [activeId, setActiveId] = useState<string>(sectionIds[0] ?? "");


### PR DESCRIPTION
## Summary

The same 5-entry section nav was duplicated in three places:
- `src/components/Menu.tsx`
- `src/components/Header.tsx`
- `src/hooks/useActiveSection.ts` (`DEFAULT_SECTIONS`)

This PR collapses those into a single `navItems` array in `src/config/site.ts`, with `SectionId` and `DEFAULT_SECTIONS` derived from it. Adding, removing, or reordering a section is now a one-file change.

## Changes

- `src/config/site.ts`: add `navItems` (with `{href, label, id}`), plus derived `NavItem` / `SectionId` types and `DEFAULT_SECTIONS`.
- `src/components/Menu.tsx`, `src/components/Header.tsx`: drop local `items` arrays; import `navItems`.
- `src/hooks/useActiveSection.ts`: import `DEFAULT_SECTIONS` and `SectionId` from `@/config/site`; re-export `SectionId` for backward compatibility.

## Verification

- `yarn lint` — clean (only pre-existing warning in `ContactForm.tsx`)
- `yarn test` — 145/145 pass across the 40 unaffected suites (the one failing suite is a pre-existing `resend` import issue on `main`, unrelated to this PR)
- `yarn type-check` — the same pre-existing `resend` error; no new errors introduced
- `Menu.test.tsx`, `Header.test.tsx`, `useActiveSection.test.ts` all still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)