### PR TITLE
refactor: deduplicate blurDataURL in project config

### DIFF
--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -2,6 +2,7 @@ import { projects } from "@/config/projects";
 import { siteConfig } from "@/config/site";
 import Badge from "@/components/Badge";
 import GlassCard from "@/components/GlassCard";
+import { DEFAULT_BLUR_DATA_URL } from "@/utils/blur";
 import Link from "next/link";
 import Image from "next/image";
 import { notFound } from "next/navigation";
@@ -188,7 +189,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
               src={project.imageSrc}
               alt={project.imageAlt}
               placeholder="blur"
-              blurDataURL={project.blurDataURL}
+              blurDataURL={DEFAULT_BLUR_DATA_URL}
               className="w-full rounded-lg"
               width={800}
               height={600}

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -1,4 +1,5 @@
 import { ProjectData } from "@/config/projects";
+import { DEFAULT_BLUR_DATA_URL } from "@/utils/blur";
 import { trackProjectDetails, trackProjectLink } from "@/utils/analytics";
 import { motion } from "framer-motion";
 import Image from "next/image";
@@ -13,7 +14,6 @@ export const Project: FC<ProjectData> = ({
   summary,
   imageSrc,
   imageAlt,
-  blurDataURL,
   link,
   repoLink,
   badges,
@@ -43,7 +43,7 @@ export const Project: FC<ProjectData> = ({
               src={imageSrc}
               alt={imageAlt}
               placeholder="blur"
-              blurDataURL={blurDataURL}
+              blurDataURL={DEFAULT_BLUR_DATA_URL}
               className="w-full rounded-lg transition-transform duration-700 ease-out group-hover:scale-[1.05]"
               width={400}
               height={300}

--- a/src/config/projects.ts
+++ b/src/config/projects.ts
@@ -6,7 +6,6 @@ export interface ProjectData {
   highlights?: string[];
   imageSrc: string;
   imageAlt: string;
-  blurDataURL?: string;
   link?: string;
   repoLink?: string;
   badges: string[];
@@ -31,8 +30,6 @@ export const projects: ProjectData[] = [
     ],
     imageSrc: "/images/projects/vibeinprod.png",
     imageAlt: "VibeInProd",
-    blurDataURL:
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAB3RJTUUH4gMOCwAaJq3CzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAADklEQVQY02NgGAWjAAMAABsAAZQ9/HoAAAAAElFTkSuQmCC",
     link: "https://vibeinprod.com",
     badges: ["TypeScript", "Next.js", "React", "AI", "Consulting"],
     projectType: "personal",
@@ -53,8 +50,6 @@ export const projects: ProjectData[] = [
     ],
     imageSrc: "/images/projects/opendrift.png",
     imageAlt: "OpenDrift",
-    blurDataURL:
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAB3RJTUUH4gMOCwAaJq3CzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAADklEQVQY02NgGAWjAAMAABsAAZQ9/HoAAAAAElFTkSuQmCC",
     link: "https://opendrift.app",
     badges: ["AI", "LLM", "TypeScript", "OpenRouter"],
     projectType: "work",
@@ -75,8 +70,6 @@ export const projects: ProjectData[] = [
     ],
     imageSrc: "/images/projects/circusconnect.png",
     imageAlt: "CircusConnect",
-    blurDataURL:
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAB3RJTUUH4gMOCwAaJq3CzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAADklEQVQY02NgGAWjAAMAABsAAZQ9/HoAAAAAElFTkSuQmCC",
     link: "https://circusconnect.com",
     badges: ["TypeScript", "Next.js", "React", "Community"],
     projectType: "work",
@@ -97,8 +90,6 @@ export const projects: ProjectData[] = [
     ],
     imageSrc: "/images/projects/payxor.png",
     imageAlt: "PayXor",
-    blurDataURL:
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAB3RJTUUH4gMOCwAaJq3CzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAADklEQVQY02NgGAWjAAMAABsAAZQ9/HoAAAAAElFTkSuQmCC",
     link: "https://payxor.xyz",
     badges: ["TypeScript", "Web3", "EVM", "Smart Contracts", "Payments"],
     projectType: "work",
@@ -119,8 +110,6 @@ export const projects: ProjectData[] = [
     ],
     imageSrc: "/images/projects/eternal-mint.png",
     imageAlt: "EternalMint",
-    blurDataURL:
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAB3RJTUUH4gMOCwAaJq3CzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAADklEQVQY02NgGAWjAAMAABsAAZQ9/HoAAAAAElFTkSuQmCC",
     link: "https://eternalmint.xyz/",
     repoLink: "https://github.com/marc-aurele-besner/eternalmint-xyz",
     badges: ["TypeScript", "Auto-SDK", "IPLD", "Blockchain", "Solidity"],
@@ -141,8 +130,6 @@ export const projects: ProjectData[] = [
     ],
     imageSrc: "/images/projects/ai3-info.png",
     imageAlt: "AI3.info",
-    blurDataURL:
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAB3RJTUUH4gMOCwAaJq3CzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAADklEQVQY02NgGAWjAAMAABsAAZQ9/HoAAAAAElFTkSuQmCC",
     link: "https://ai3.info",
     repoLink: "https://github.com/marc-aurele-besner/ai3-info",
     badges: [
@@ -170,8 +157,6 @@ export const projects: ProjectData[] = [
     ],
     imageSrc: "/images/projects/astral-block-explorer.png",
     imageAlt: "Astral Block Explorer",
-    blurDataURL:
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAB3RJTUUH4gMOCwAaJq3CzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAADklEQVQY02NgGAWjAAMAABsAAZQ9/HoAAAAAElFTkSuQmCC",
     repoLink: "https://github.com/autonomys/astral",
     badges: ["Next.js", "React", "Polkadot.js", "TypeScript", "GraphQL"],
     projectType: "work",
@@ -192,8 +177,6 @@ export const projects: ProjectData[] = [
     ],
     imageSrc: "/images/projects/fileonchain.png",
     imageAlt: "FileOnChain",
-    blurDataURL:
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAB3RJTUUH4gMOCwAaJq3CzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAADklEQVQY02NgGAWjAAMAABsAAZQ9/HoAAAAAElFTkSuQmCC",
     link: "https://fileonchain.org/",
     repoLink: "https://github.com/marc-aurele-besner/consensus-hackathon-2024",
     badges: ["TypeScript", "Polkadot.js", "IPLD", "Blockchain"],
@@ -215,8 +198,6 @@ export const projects: ProjectData[] = [
     ],
     imageSrc: "/images/projects/autonomys-auto-sdk.png",
     imageAlt: "Autonomys Auto-SDK",
-    blurDataURL:
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAB3RJTUUH4gMOCwAaJq3CzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAADklEQVQY02NgGAWjAAMAABsAAZQ9/HoAAAAAElFTkSuQmCC",
     link: "https://www.npmjs.com/package/@autonomys/auto-consensus",
     repoLink: "https://github.com/autonomys/auto-sdk",
     badges: ["TypeScript", "SDK", "Web3", "AI", "Blockchain"],
@@ -238,8 +219,6 @@ export const projects: ProjectData[] = [
     ],
     imageSrc: "/images/projects/oamo.png",
     imageAlt: "Oamo App",
-    blurDataURL:
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAB3RJTUUH4gMOCwAaJq3CzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAADklEQVQY02NgGAWjAAMAABsAAZQ9/HoAAAAAElFTkSuQmCC",
     link: "https://oamo.io",
     badges: ["TypeScript", "Next.js", "React", "Web3", "Solidity", "OAuth"],
     projectType: "work",
@@ -258,8 +237,6 @@ export const projects: ProjectData[] = [
     ],
     imageSrc: "/images/projects/my-multisig.png",
     imageAlt: "MyMultisig",
-    blurDataURL:
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAB3RJTUUH4gMOCwAaJq3CzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAADklEQVQY02NgGAWjAAMAABsAAZQ9/HoAAAAAElFTkSuQmCC",
     link: "https://mymultisig.app/",
     repoLink: "https://github.com/marc-aurele-besner/mymultisig-contract",
     badges: ["TypeScript", "Next.js", "React", "Web3", "Solidity"],
@@ -279,8 +256,6 @@ export const projects: ProjectData[] = [
     ],
     imageSrc: "/images/projects/collage-of-myself.png",
     imageAlt: "CollageOfMyself",
-    blurDataURL:
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAB3RJTUUH4gMOCwAaJq3CzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAADklEQVQY02NgGAWjAAMAABsAAZQ9/HoAAAAAElFTkSuQmCC",
     link: "https://collageofmyself.com/",
     repoLink: "https://github.com/collageofmyself/collageofmyself-contract",
     badges: ["TypeScript", "Next.js", "React", "Web3", "Solidity"],
@@ -301,8 +276,6 @@ export const projects: ProjectData[] = [
     ],
     imageSrc: "/images/projects/plantswap.png",
     imageAlt: "PlantSwap Finance",
-    blurDataURL:
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAB3RJTUUH4gMOCwAaJq3CzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAADklEQVQY02NgGAWjAAMAABsAAZQ9/HoAAAAAElFTkSuQmCC",
     link: "https://plantswap.finance/",
     repoLink: "https://github.com/PlantSwapFinance/plantswapfinance-contracts",
     badges: ["TypeScript", "Next.js", "React", "Web3", "Solidity"],
@@ -322,8 +295,6 @@ export const projects: ProjectData[] = [
     ],
     imageSrc: "/images/projects/golf-alpine.png",
     imageAlt: "Golf Alpine",
-    blurDataURL:
-      "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAB3RJTUUH4gMOCwAaJq3CzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAADklEQVQY02NgGAWjAAMAABsAAZQ9/HoAAAAAElFTkSuQmCC",
     link: "https://golfalpine.ca/",
     repoLink: "https://github.com/marc-aurele-besner/golfalpine.ca",
     badges: ["TypeScript", "React", "CSS"],

--- a/src/utils/blur.ts
+++ b/src/utils/blur.ts
@@ -1,3 +1,4 @@
-// Base64-encoded 1x1 transparent pixel for blur placeholder
+// Base64-encoded 10x10 grey placeholder used while project cover images load.
+// Centralized so consumers don't need to inline the value.
 export const DEFAULT_BLUR_DATA_URL =
-  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mN8/+F9PRQw7gT0nALaAAAAAElFTkSuQmCC";
+  "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAB3RJTUUH4gMOCwAaJq3CzQAAAB1pVFh0Q29tbWVudAAAAAAAQ3JlYXRlZCB3aXRoIEdJTVBkLmUHAAAADklEQVQY02NgGAWjAAMAABsAAZQ9/HoAAAAAElFTkSuQmCC";


### PR DESCRIPTION
## Summary

All 14 entries in `src/config/projects.ts` defined the exact same `blurDataURL` placeholder string, while `src/utils/blur.ts` exported a `DEFAULT_BLUR_DATA_URL` constant that wasn't being imported anywhere (and used a *different* placeholder value). This PR consolidates to a single source of truth and removes ~30 lines of config noise.

## Changes

- `src/utils/blur.ts`: `DEFAULT_BLUR_DATA_URL` now holds the canonical placeholder value the projects were actually using.
- `src/components/Project.tsx`: drops the local `blurDataURL` prop, imports `DEFAULT_BLUR_DATA_URL` directly.
- `src/app/projects/[slug]/page.tsx`: replaces `project.blurDataURL` with `DEFAULT_BLUR_DATA_URL`.
- `src/config/projects.ts`: removes the optional `blurDataURL?: string` field from `ProjectData` and the 14 repeated entries.

## Why drop the field entirely (vs. keep + fallback)

The user's brief offered two options — fall back with `?? DEFAULT_BLUR_DATA_URL` and keep the optional field, or drop the field. I went with drop because every project had the same value, the optional field carried no real per-project intent, and dropping keeps the consumer code simpler (no fallback ceremony).

## Verification

- `yarn lint` — clean (only pre-existing unused-var warning in `ContactForm.tsx`).
- `yarn test --run` — 145/145 pass; the one suite that fails to transform is the pre-existing `resend` import error on `main`, unrelated to this PR.
- Confirmed visually: only placeholders are the two consumer sites in `Project.tsx:46` and `page.tsx:192`, both using `DEFAULT_BLUR_DATA_URL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)