### PR TITLE
refactor: extract formatProjectType() helper

### DIFF
--- a/src/app/projects/[slug]/opengraph-image.tsx
+++ b/src/app/projects/[slug]/opengraph-image.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from "next/og";
 import { projects } from "@/config/projects";
 import { ogImageSize, siteConfig } from "@/config/site";
+import { formatProjectType } from "@/utils/project-type";
 
 export const size = ogImageSize;
 
@@ -43,7 +44,7 @@ export default async function OGImage({
   }
 
   const badgesText = project.badges.slice(0, 4).join(" • ");
-  const projectType = project.projectType === "personal" ? "Personal Project" : "Work Project";
+  const projectType = formatProjectType(project.projectType);
 
   return new ImageResponse(
     (

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -3,6 +3,7 @@ import { siteConfig } from "@/config/site";
 import Badge from "@/components/Badge";
 import GlassCard from "@/components/GlassCard";
 import { DEFAULT_BLUR_DATA_URL } from "@/utils/blur";
+import { formatProjectType } from "@/utils/project-type";
 import Link from "next/link";
 import Image from "next/image";
 import { notFound } from "next/navigation";
@@ -43,7 +44,7 @@ export async function generateMetadata({
       "Web3",
       "Blockchain",
       "Project",
-      project.projectType === "personal" ? "Personal Project" : "Work Project",
+      formatProjectType(project.projectType),
     ],
     alternates: {
       canonical: url,
@@ -155,9 +156,7 @@ export default async function ProjectPage({ params }: ProjectPageProps) {
               <span
                 className={`inline-block px-3 py-1.5 text-xs sm:text-sm font-semibold rounded-full border border-[var(--accent-weak)] text-[var(--accent)]`}
               >
-                {project.projectType === "personal"
-                  ? "Personal Project"
-                  : "Work Project"}
+                {formatProjectType(project.projectType)}
               </span>
             </div>
             <div className="flex items-center gap-4">

--- a/src/app/projects/[slug]/twitter-image.tsx
+++ b/src/app/projects/[slug]/twitter-image.tsx
@@ -1,6 +1,7 @@
 import { ImageResponse } from "next/og";
 import { projects } from "@/config/projects";
 import { ogImageSize, siteConfig } from "@/config/site";
+import { formatProjectType } from "@/utils/project-type";
 
 export const size = ogImageSize;
 
@@ -43,7 +44,7 @@ export default async function TwitterImage({
   }
 
   const badgesText = project.badges.slice(0, 4).join(" • ");
-  const projectType = project.projectType === "personal" ? "Personal Project" : "Work Project";
+  const projectType = formatProjectType(project.projectType);
 
   return new ImageResponse(
     (

--- a/src/components/Project.tsx
+++ b/src/components/Project.tsx
@@ -1,5 +1,6 @@
 import { ProjectData } from "@/config/projects";
 import { DEFAULT_BLUR_DATA_URL } from "@/utils/blur";
+import { formatProjectType } from "@/utils/project-type";
 import { trackProjectDetails, trackProjectLink } from "@/utils/analytics";
 import { motion } from "framer-motion";
 import Image from "next/image";
@@ -53,11 +54,9 @@ export const Project: FC<ProjectData> = ({
           </div>
           <span
             className="inline-block px-3 py-1.5 text-xs sm:text-sm font-semibold rounded-full border mt-3 transition-all duration-300 border-[var(--accent-weak)] text-[var(--accent)] bg-transparent hover:bg-[var(--accent-bg-weak)] hover:border-[var(--accent)]"
-            aria-label={`Project type: ${
-              projectType === "personal" ? "Personal Project" : "Work Project"
-            }`}
+            aria-label={`Project type: ${formatProjectType(projectType)}`}
           >
-            {projectType === "personal" ? "Personal Project" : "Work Project"}
+            {formatProjectType(projectType)}
           </span>
         </div>
       </Link>

--- a/src/utils/project-type.ts
+++ b/src/utils/project-type.ts
@@ -1,0 +1,6 @@
+// Maps a projectType slug to its display label. Used by the project card,
+// detail page badge, and OG/Twitter image metadata so the label stays in
+// sync everywhere.
+export function formatProjectType(type: "personal" | "work") {
+  return type === "personal" ? "Personal Project" : "Work Project";
+}


### PR DESCRIPTION
## Summary

The `projectType === "personal" ? "Personal Project" : "Work Project"` ternary was inlined in five places: the project card, the detail page badge + metadata keywords, and both OG and Twitter image routes. Hoist it to `src/utils/project-type.ts` so the label lives in one spot.

## Changes

- **New** `src/utils/project-type.ts` — exports `formatProjectType(type: "personal" | "work")`
- `src/components/Project.tsx` — card badge + aria-label now use the helper
- `src/app/projects/[slug]/page.tsx` — detail page badge + metadata keywords now use the helper
- `src/app/projects/[slug]/opengraph-image.tsx` — OG image now uses the helper
- `src/app/projects/[slug]/twitter-image.tsx` — Twitter image now uses the helper

## Verification

- `yarn lint` — clean (only the pre-existing `ContactForm.tsx` unused-var warning)
- `yarn type-check` — fails on pre-existing `resend` module resolution in `src/app/actions/contact.ts` (unrelated to this PR; reproduces on `origin/main`)
- `yarn test --run` — 145 tests pass; the lone file-level load failure is the same `resend` issue, also pre-existing
- The 21 tests across the four touched consumers (`Project.test.tsx`, `page.test.tsx`, `opengraph-image.test.ts`, `twitter-image.test.ts`) still assert the exact label strings and all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)