### PR TITLE
refactor: add slug lookup helpers

### DIFF
--- a/src/app/experience/[slug]/opengraph-image.test.ts
+++ b/src/app/experience/[slug]/opengraph-image.test.ts
@@ -42,6 +42,7 @@ const mockExperiences = [
 
 describe("Experience OG Image", () => {
   let originalExperiences: typeof experienceModule.experiences;
+  let originalGetExperienceBySlug: typeof experienceModule.getExperienceBySlug;
   let originalSiteConfigUrl: string;
   let originalSiteConfigName: string;
 
@@ -49,6 +50,12 @@ describe("Experience OG Image", () => {
     originalExperiences = experienceModule.experiences;
     Object.defineProperty(experienceModule, "experiences", {
       value: mockExperiences,
+      writable: true,
+    });
+
+    originalGetExperienceBySlug = experienceModule.getExperienceBySlug;
+    Object.defineProperty(experienceModule, "getExperienceBySlug", {
+      value: (slug: string) => mockExperiences.find((e) => e.slug === slug),
       writable: true,
     });
 
@@ -61,6 +68,10 @@ describe("Experience OG Image", () => {
   afterEach(() => {
     Object.defineProperty(experienceModule, "experiences", {
       value: originalExperiences,
+      writable: true,
+    });
+    Object.defineProperty(experienceModule, "getExperienceBySlug", {
+      value: originalGetExperienceBySlug,
       writable: true,
     });
     siteConfigModule.siteConfig.url = originalSiteConfigUrl;

--- a/src/app/experience/[slug]/opengraph-image.tsx
+++ b/src/app/experience/[slug]/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from "next/og";
-import { experiences } from "@/config/experience";
+import { experiences, getExperienceBySlug } from "@/config/experience";
 import { ogImageSize, siteConfig } from "@/config/site";
 
 export const size = ogImageSize;
@@ -18,7 +18,7 @@ export default async function OGImage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const experience = experiences.find((exp) => exp.slug === slug);
+  const experience = getExperienceBySlug(slug);
 
   if (!experience) {
     return new ImageResponse(

--- a/src/app/experience/[slug]/page.test.tsx
+++ b/src/app/experience/[slug]/page.test.tsx
@@ -71,12 +71,33 @@ const mockExperiences = [
 
 describe("Experience Page", () => {
   let originalExperiences: typeof experienceModule.experiences;
+  let originalGetExperienceBySlug: typeof experienceModule.getExperienceBySlug;
+  let originalGetAdjacentExperiences: typeof experienceModule.getAdjacentExperiences;
   let originalSiteConfig: typeof siteConfigModule.siteConfig;
 
   beforeEach(() => {
     originalExperiences = experienceModule.experiences;
     Object.defineProperty(experienceModule, "experiences", {
       value: mockExperiences,
+      writable: true,
+    });
+
+    originalGetExperienceBySlug = experienceModule.getExperienceBySlug;
+    Object.defineProperty(experienceModule, "getExperienceBySlug", {
+      value: (slug: string) => mockExperiences.find((e) => e.slug === slug),
+      writable: true,
+    });
+
+    originalGetAdjacentExperiences = experienceModule.getAdjacentExperiences;
+    Object.defineProperty(experienceModule, "getAdjacentExperiences", {
+      value: (slug: string) => {
+        const idx = mockExperiences.findIndex((e) => e.slug === slug);
+        if (idx === -1) return { prev: null, next: null };
+        return {
+          prev: idx > 0 ? mockExperiences[idx - 1] : null,
+          next: idx < mockExperiences.length - 1 ? mockExperiences[idx + 1] : null,
+        };
+      },
       writable: true,
     });
 
@@ -96,6 +117,14 @@ describe("Experience Page", () => {
   afterEach(() => {
     Object.defineProperty(experienceModule, "experiences", {
       value: originalExperiences,
+      writable: true,
+    });
+    Object.defineProperty(experienceModule, "getExperienceBySlug", {
+      value: originalGetExperienceBySlug,
+      writable: true,
+    });
+    Object.defineProperty(experienceModule, "getAdjacentExperiences", {
+      value: originalGetAdjacentExperiences,
       writable: true,
     });
     Object.defineProperty(siteConfigModule, "siteConfig", {

--- a/src/app/experience/[slug]/page.tsx
+++ b/src/app/experience/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { experiences } from "@/config/experience";
+import { experiences, getExperienceBySlug, getAdjacentExperiences } from "@/config/experience";
 import { siteConfig } from "@/config/site";
 import Badge from "@/components/Badge";
 import GlassCard from "@/components/GlassCard";
@@ -20,7 +20,7 @@ export async function generateMetadata({
   params,
 }: ExperiencePageProps): Promise<Metadata> {
   const { slug } = await params;
-  const experience = experiences.find((exp) => exp.slug === slug);
+  const experience = getExperienceBySlug(slug);
 
   if (!experience) {
     return {
@@ -64,17 +64,14 @@ export async function generateMetadata({
 
 export default async function ExperiencePage({ params }: ExperiencePageProps) {
   const { slug } = await params;
-  const experience = experiences.find((exp) => exp.slug === slug);
+  const experience = getExperienceBySlug(slug);
 
   if (!experience) {
     notFound();
     return null; // Explicitly return null after notFound()
   }
 
-  const currentIndex = experiences.findIndex((exp) => exp.slug === slug);
-  const prevExperience = currentIndex > 0 ? experiences[currentIndex - 1] : null;
-  const nextExperience =
-    currentIndex < experiences.length - 1 ? experiences[currentIndex + 1] : null;
+  const { prev: prevExperience, next: nextExperience } = getAdjacentExperiences(slug);
 
   return (
     <div className="max-w-4xl mx-auto py-8">

--- a/src/app/experience/[slug]/twitter-image.test.ts
+++ b/src/app/experience/[slug]/twitter-image.test.ts
@@ -42,6 +42,7 @@ const mockExperiences = [
 
 describe("Experience Twitter Image", () => {
   let originalExperiences: typeof experienceModule.experiences;
+  let originalGetExperienceBySlug: typeof experienceModule.getExperienceBySlug;
   let originalSiteConfigName: string;
   let originalSiteConfigTwitterHandle: string;
 
@@ -49,6 +50,12 @@ describe("Experience Twitter Image", () => {
     originalExperiences = experienceModule.experiences;
     Object.defineProperty(experienceModule, "experiences", {
       value: mockExperiences,
+      writable: true,
+    });
+
+    originalGetExperienceBySlug = experienceModule.getExperienceBySlug;
+    Object.defineProperty(experienceModule, "getExperienceBySlug", {
+      value: (slug: string) => mockExperiences.find((e) => e.slug === slug),
       writable: true,
     });
 
@@ -61,6 +68,10 @@ describe("Experience Twitter Image", () => {
   afterEach(() => {
     Object.defineProperty(experienceModule, "experiences", {
       value: originalExperiences,
+      writable: true,
+    });
+    Object.defineProperty(experienceModule, "getExperienceBySlug", {
+      value: originalGetExperienceBySlug,
       writable: true,
     });
     siteConfigModule.siteConfig.name = originalSiteConfigName;

--- a/src/app/experience/[slug]/twitter-image.tsx
+++ b/src/app/experience/[slug]/twitter-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from "next/og";
-import { experiences } from "@/config/experience";
+import { experiences, getExperienceBySlug } from "@/config/experience";
 import { ogImageSize, siteConfig } from "@/config/site";
 
 export const size = ogImageSize;
@@ -18,7 +18,7 @@ export default async function TwitterImage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const experience = experiences.find((exp) => exp.slug === slug);
+  const experience = getExperienceBySlug(slug);
 
   if (!experience) {
     return new ImageResponse(

--- a/src/app/projects/[slug]/opengraph-image.test.ts
+++ b/src/app/projects/[slug]/opengraph-image.test.ts
@@ -40,6 +40,7 @@ const mockProjects = [
 
 describe("Project OG Image", () => {
   let originalProjects: typeof projectModule.projects;
+  let originalGetProjectBySlug: typeof projectModule.getProjectBySlug;
   let originalSiteConfigUrl: string;
   let originalSiteConfigName: string;
 
@@ -47,6 +48,12 @@ describe("Project OG Image", () => {
     originalProjects = projectModule.projects;
     Object.defineProperty(projectModule, "projects", {
       value: mockProjects,
+      writable: true,
+    });
+
+    originalGetProjectBySlug = projectModule.getProjectBySlug;
+    Object.defineProperty(projectModule, "getProjectBySlug", {
+      value: (slug: string) => mockProjects.find((p) => p.slug === slug),
       writable: true,
     });
 
@@ -59,6 +66,10 @@ describe("Project OG Image", () => {
   afterEach(() => {
     Object.defineProperty(projectModule, "projects", {
       value: originalProjects,
+      writable: true,
+    });
+    Object.defineProperty(projectModule, "getProjectBySlug", {
+      value: originalGetProjectBySlug,
       writable: true,
     });
     siteConfigModule.siteConfig.url = originalSiteConfigUrl;

--- a/src/app/projects/[slug]/opengraph-image.tsx
+++ b/src/app/projects/[slug]/opengraph-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from "next/og";
-import { projects } from "@/config/projects";
+import { projects, getProjectBySlug } from "@/config/projects";
 import { ogImageSize, siteConfig } from "@/config/site";
 import { formatProjectType } from "@/utils/project-type";
 
@@ -19,7 +19,7 @@ export default async function OGImage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const project = projects.find((p) => p.slug === slug);
+  const project = getProjectBySlug(slug);
 
   if (!project) {
     return new ImageResponse(

--- a/src/app/projects/[slug]/page.test.tsx
+++ b/src/app/projects/[slug]/page.test.tsx
@@ -75,12 +75,33 @@ const mockProjects = [
 
 describe("Project Page", () => {
   let originalProjects: typeof projectModule.projects;
+  let originalGetProjectBySlug: typeof projectModule.getProjectBySlug;
+  let originalGetAdjacentProjects: typeof projectModule.getAdjacentProjects;
   let originalSiteConfig: typeof siteConfigModule.siteConfig;
 
   beforeEach(() => {
     originalProjects = projectModule.projects;
     Object.defineProperty(projectModule, "projects", {
       value: mockProjects,
+      writable: true,
+    });
+
+    originalGetProjectBySlug = projectModule.getProjectBySlug;
+    Object.defineProperty(projectModule, "getProjectBySlug", {
+      value: (slug: string) => mockProjects.find((p) => p.slug === slug),
+      writable: true,
+    });
+
+    originalGetAdjacentProjects = projectModule.getAdjacentProjects;
+    Object.defineProperty(projectModule, "getAdjacentProjects", {
+      value: (slug: string) => {
+        const idx = mockProjects.findIndex((p) => p.slug === slug);
+        if (idx === -1) return { prev: null, next: null };
+        return {
+          prev: idx > 0 ? mockProjects[idx - 1] : null,
+          next: idx < mockProjects.length - 1 ? mockProjects[idx + 1] : null,
+        };
+      },
       writable: true,
     });
 
@@ -100,6 +121,14 @@ describe("Project Page", () => {
   afterEach(() => {
     Object.defineProperty(projectModule, "projects", {
       value: originalProjects,
+      writable: true,
+    });
+    Object.defineProperty(projectModule, "getProjectBySlug", {
+      value: originalGetProjectBySlug,
+      writable: true,
+    });
+    Object.defineProperty(projectModule, "getAdjacentProjects", {
+      value: originalGetAdjacentProjects,
       writable: true,
     });
     Object.defineProperty(siteConfigModule, "siteConfig", {

--- a/src/app/projects/[slug]/page.tsx
+++ b/src/app/projects/[slug]/page.tsx
@@ -1,4 +1,4 @@
-import { projects } from "@/config/projects";
+import { projects, getProjectBySlug, getAdjacentProjects } from "@/config/projects";
 import { siteConfig } from "@/config/site";
 import Badge from "@/components/Badge";
 import GlassCard from "@/components/GlassCard";
@@ -23,7 +23,7 @@ export async function generateMetadata({
   params,
 }: ProjectPageProps): Promise<Metadata> {
   const { slug } = await params;
-  const project = projects.find((p) => p.slug === slug);
+  const project = getProjectBySlug(slug);
 
   if (!project) {
     return {
@@ -67,17 +67,14 @@ export async function generateMetadata({
 
 export default async function ProjectPage({ params }: ProjectPageProps) {
   const { slug } = await params;
-  const project = projects.find((p) => p.slug === slug);
+  const project = getProjectBySlug(slug);
 
   if (!project) {
     notFound();
     return null;
   }
 
-  const currentIndex = projects.findIndex((p) => p.slug === slug);
-  const prevProject = currentIndex > 0 ? projects[currentIndex - 1] : null;
-  const nextProject =
-    currentIndex < projects.length - 1 ? projects[currentIndex + 1] : null;
+  const { prev: prevProject, next: nextProject } = getAdjacentProjects(slug);
 
   // JSON-LD structured data for software application
   const jsonLd = {

--- a/src/app/projects/[slug]/twitter-image.test.ts
+++ b/src/app/projects/[slug]/twitter-image.test.ts
@@ -40,6 +40,7 @@ const mockProjects = [
 
 describe("Project Twitter Image", () => {
   let originalProjects: typeof projectModule.projects;
+  let originalGetProjectBySlug: typeof projectModule.getProjectBySlug;
   let originalSiteConfigName: string;
   let originalSiteConfigTwitterHandle: string;
 
@@ -47,6 +48,12 @@ describe("Project Twitter Image", () => {
     originalProjects = projectModule.projects;
     Object.defineProperty(projectModule, "projects", {
       value: mockProjects,
+      writable: true,
+    });
+
+    originalGetProjectBySlug = projectModule.getProjectBySlug;
+    Object.defineProperty(projectModule, "getProjectBySlug", {
+      value: (slug: string) => mockProjects.find((p) => p.slug === slug),
       writable: true,
     });
 
@@ -59,6 +66,10 @@ describe("Project Twitter Image", () => {
   afterEach(() => {
     Object.defineProperty(projectModule, "projects", {
       value: originalProjects,
+      writable: true,
+    });
+    Object.defineProperty(projectModule, "getProjectBySlug", {
+      value: originalGetProjectBySlug,
       writable: true,
     });
     siteConfigModule.siteConfig.name = originalSiteConfigName;

--- a/src/app/projects/[slug]/twitter-image.tsx
+++ b/src/app/projects/[slug]/twitter-image.tsx
@@ -1,5 +1,5 @@
 import { ImageResponse } from "next/og";
-import { projects } from "@/config/projects";
+import { projects, getProjectBySlug } from "@/config/projects";
 import { ogImageSize, siteConfig } from "@/config/site";
 import { formatProjectType } from "@/utils/project-type";
 
@@ -19,7 +19,7 @@ export default async function TwitterImage({
   params: Promise<{ slug: string }>;
 }) {
   const { slug } = await params;
-  const project = projects.find((p) => p.slug === slug);
+  const project = getProjectBySlug(slug);
 
   if (!project) {
     return new ImageResponse(

--- a/src/config/experience.test.ts
+++ b/src/config/experience.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { experiences, type ExperienceData } from "./experience";
+import {
+  experiences,
+  getExperienceBySlug,
+  getAdjacentExperiences,
+  type ExperienceData,
+} from "./experience";
 
 describe("experience config", () => {
   it("should have at least one experience", () => {
@@ -31,6 +36,44 @@ describe("experience config", () => {
       expect(exp.highlights.length).toBeGreaterThan(0);
       expect(exp.skills.length).toBeGreaterThan(0);
       expect(typeof exp.isWeb3).toBe("boolean");
+    });
+  });
+});
+
+describe("getExperienceBySlug", () => {
+  it("should return the matching experience", () => {
+    const first = experiences[0];
+    expect(getExperienceBySlug(first.slug)).toBe(first);
+  });
+
+  it("should return undefined for an unknown slug", () => {
+    expect(getExperienceBySlug("does-not-exist")).toBeUndefined();
+  });
+});
+
+describe("getAdjacentExperiences", () => {
+  it("should return both neighbors for an experience in the middle", () => {
+    const { prev, next } = getAdjacentExperiences(experiences[1].slug);
+    expect(prev).toBe(experiences[0]);
+    expect(next).toBe(experiences[2]);
+  });
+
+  it("should return null prev and a next for the first experience", () => {
+    const { prev, next } = getAdjacentExperiences(experiences[0].slug);
+    expect(prev).toBeNull();
+    expect(next).toBe(experiences[1]);
+  });
+
+  it("should return a prev and null next for the last experience", () => {
+    const { prev, next } = getAdjacentExperiences(experiences[experiences.length - 1].slug);
+    expect(prev).toBe(experiences[experiences.length - 2]);
+    expect(next).toBeNull();
+  });
+
+  it("should return null neighbors for an unknown slug", () => {
+    expect(getAdjacentExperiences("does-not-exist")).toEqual({
+      prev: null,
+      next: null,
     });
   });
 });

--- a/src/config/experience.ts
+++ b/src/config/experience.ts
@@ -223,3 +223,35 @@ export const experiences: ExperienceData[] = [
     isWeb3: false,
   },
 ];
+
+/**
+ * Look up an experience by its slug.
+ *
+ * @returns the matching experience, or `undefined` if none exists.
+ */
+export function getExperienceBySlug(slug: string): ExperienceData | undefined {
+  return experiences.find((exp) => exp.slug === slug);
+}
+
+export interface AdjacentExperiences {
+  /** Previous experience in the list, or `null` if `slug` is the first. */
+  prev: ExperienceData | null;
+  /** Next experience in the list, or `null` if `slug` is the last. */
+  next: ExperienceData | null;
+}
+
+/**
+ * Find the experiences that come immediately before and after the given slug
+ * in the `experiences` array. Returns `{ prev: null, next: null }` when the
+ * slug does not match any experience.
+ */
+export function getAdjacentExperiences(slug: string): AdjacentExperiences {
+  const currentIndex = experiences.findIndex((exp) => exp.slug === slug);
+  if (currentIndex === -1) {
+    return { prev: null, next: null };
+  }
+  return {
+    prev: currentIndex > 0 ? experiences[currentIndex - 1] : null,
+    next: currentIndex < experiences.length - 1 ? experiences[currentIndex + 1] : null,
+  };
+}

--- a/src/config/projects.test.ts
+++ b/src/config/projects.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from "vitest";
-import { projects, type ProjectData } from "./projects";
+import {
+  projects,
+  getProjectBySlug,
+  getAdjacentProjects,
+  type ProjectData,
+} from "./projects";
 
 describe("projects config", () => {
   it("should have at least one project", () => {
@@ -34,6 +39,44 @@ describe("projects config", () => {
   it("should have valid image paths", () => {
     projects.forEach((project) => {
       expect(project.imageSrc).toMatch(/^\/images\/projects\/.+\.(png|jpg|jpeg|webp)$/);
+    });
+  });
+});
+
+describe("getProjectBySlug", () => {
+  it("should return the matching project", () => {
+    const first = projects[0];
+    expect(getProjectBySlug(first.slug)).toBe(first);
+  });
+
+  it("should return undefined for an unknown slug", () => {
+    expect(getProjectBySlug("does-not-exist")).toBeUndefined();
+  });
+});
+
+describe("getAdjacentProjects", () => {
+  it("should return both neighbors for a project in the middle", () => {
+    const { prev, next } = getAdjacentProjects(projects[1].slug);
+    expect(prev).toBe(projects[0]);
+    expect(next).toBe(projects[2]);
+  });
+
+  it("should return null prev and a next for the first project", () => {
+    const { prev, next } = getAdjacentProjects(projects[0].slug);
+    expect(prev).toBeNull();
+    expect(next).toBe(projects[1]);
+  });
+
+  it("should return a prev and null next for the last project", () => {
+    const { prev, next } = getAdjacentProjects(projects[projects.length - 1].slug);
+    expect(prev).toBe(projects[projects.length - 2]);
+    expect(next).toBeNull();
+  });
+
+  it("should return null neighbors for an unknown slug", () => {
+    expect(getAdjacentProjects("does-not-exist")).toEqual({
+      prev: null,
+      next: null,
     });
   });
 });

--- a/src/config/projects.ts
+++ b/src/config/projects.ts
@@ -302,3 +302,35 @@ export const projects: ProjectData[] = [
     featured: false,
   },
 ];
+
+/**
+ * Look up a project by its slug.
+ *
+ * @returns the matching project, or `undefined` if none exists.
+ */
+export function getProjectBySlug(slug: string): ProjectData | undefined {
+  return projects.find((p) => p.slug === slug);
+}
+
+export interface AdjacentProjects {
+  /** Previous project in the list, or `null` if `slug` is the first project. */
+  prev: ProjectData | null;
+  /** Next project in the list, or `null` if `slug` is the last project. */
+  next: ProjectData | null;
+}
+
+/**
+ * Find the projects that come immediately before and after the given slug in
+ * the `projects` array. Returns `{ prev: null, next: null }` when the slug
+ * does not match any project.
+ */
+export function getAdjacentProjects(slug: string): AdjacentProjects {
+  const currentIndex = projects.findIndex((p) => p.slug === slug);
+  if (currentIndex === -1) {
+    return { prev: null, next: null };
+  }
+  return {
+    prev: currentIndex > 0 ? projects[currentIndex - 1] : null,
+    next: currentIndex < projects.length - 1 ? projects[currentIndex + 1] : null,
+  };
+}


### PR DESCRIPTION
## Summary

Centralize the slug lookup pattern that was duplicated across six consumer files (project/experience `[slug]` page and OG/Twitter image routes).

## Changes

### New helpers in `src/config/`

- `getProjectBySlug(slug)` and `getAdjacentProjects(slug)` in `projects.ts`
- `getExperienceBySlug(slug)` and `getAdjacentExperiences(slug)` in `experience.ts`

`getAdjacentProjects` / `getAdjacentExperiences` return `{ prev, next }`, with `null` at the boundaries and for unknown slugs.

### Refactored consumers

- `src/app/projects/[slug]/page.tsx` — collapsed the `findIndex` + boundary-check math into a single destructured call
- `src/app/experience/[slug]/page.tsx` — same
- `src/app/projects/[slug]/opengraph-image.tsx`
- `src/app/projects/[slug]/twitter-image.tsx`
- `src/app/experience/[slug]/opengraph-image.tsx`
- `src/app/experience/[slug]/twitter-image.tsx`

### Tests

- Added unit tests for the new helpers (found, not-found, first with no prev, last with no next, unknown slug)
- Updated the existing page and image tests to also mock the new helpers (the original data-array mock no longer reaches the helper's internal `find`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)