### PR TITLE
refactor(analytics): wire trackSectionView into useActiveSection

### DIFF
--- a/src/hooks/useActiveSection.test.ts
+++ b/src/hooks/useActiveSection.test.ts
@@ -1,5 +1,10 @@
 import { renderHook, act } from "@testing-library/react";
+import { sendGAEvent } from "@next/third-parties/google";
 import { useActiveSection } from "./useActiveSection";
+
+vi.mock("@next/third-parties/google", () => ({
+  sendGAEvent: vi.fn(),
+}));
 
 const mockIntersectionObserver = vi.fn((_callback: IntersectionObserverCallback) => ({
   observe: vi.fn(),
@@ -14,6 +19,7 @@ const sectionIds = ["about", "experience", "projects", "advisory", "contact"] as
 describe("useActiveSection", () => {
   beforeEach(() => {
     mockIntersectionObserver.mockClear();
+    vi.mocked(sendGAEvent).mockClear();
     sectionIds.forEach((id) => {
       const el = document.createElement("div");
       el.id = id;
@@ -101,5 +107,69 @@ describe("useActiveSection", () => {
     });
 
     expect(result.current.activeId).toBe("experience");
+  });
+
+  it("should track a view_section event for the initial section on mount", () => {
+    renderHook(() => useActiveSection());
+    expect(sendGAEvent).toHaveBeenCalledWith("event", "view_section", { section: "about" });
+  });
+
+  it("should track view_section only once per section change", () => {
+    const { result } = renderHook(() => useActiveSection());
+    const observerCallback =
+      mockIntersectionObserver.mock.calls[0]?.[0] as
+        | IntersectionObserverCallback
+        | undefined;
+    if (!observerCallback) throw new Error("Missing observer callback");
+    const projectsEl = document.getElementById("projects") as Element;
+    const experienceEl = document.getElementById("experience") as Element;
+    const advisoryEl = document.getElementById("advisory") as Element;
+
+    // Initial mount already fires "about"; clear so we count only transitions.
+    vi.mocked(sendGAEvent).mockClear();
+
+    act(() => {
+      observerCallback(
+        [{ isIntersecting: true, intersectionRatio: 0.8, target: projectsEl }] as unknown as IntersectionObserverEntry[],
+        {} as IntersectionObserver
+      );
+    });
+    expect(result.current.activeId).toBe("projects");
+    expect(sendGAEvent).toHaveBeenCalledTimes(1);
+    expect(sendGAEvent).toHaveBeenLastCalledWith("event", "view_section", { section: "projects" });
+
+    // Repeating the same entry should not re-fire.
+    act(() => {
+      observerCallback(
+        [{ isIntersecting: true, intersectionRatio: 0.9, target: projectsEl }] as unknown as IntersectionObserverEntry[],
+        {} as IntersectionObserver
+      );
+    });
+    expect(sendGAEvent).toHaveBeenCalledTimes(1);
+
+    act(() => {
+      observerCallback(
+        [{ isIntersecting: true, intersectionRatio: 0.6, target: experienceEl }] as unknown as IntersectionObserverEntry[],
+        {} as IntersectionObserver
+      );
+    });
+    expect(result.current.activeId).toBe("experience");
+    expect(sendGAEvent).toHaveBeenCalledTimes(2);
+    expect(sendGAEvent).toHaveBeenLastCalledWith("event", "view_section", { section: "experience" });
+
+    act(() => {
+      observerCallback(
+        [{ isIntersecting: true, intersectionRatio: 0.7, target: advisoryEl }] as unknown as IntersectionObserverEntry[],
+        {} as IntersectionObserver
+      );
+    });
+    expect(result.current.activeId).toBe("advisory");
+    expect(sendGAEvent).toHaveBeenCalledTimes(3);
+    expect(sendGAEvent).toHaveBeenLastCalledWith("event", "view_section", { section: "advisory" });
+  });
+
+  it("should not track view_section when activeId is empty", () => {
+    renderHook(() => useActiveSection([]));
+    expect(sendGAEvent).not.toHaveBeenCalled();
   });
 });

--- a/src/hooks/useActiveSection.ts
+++ b/src/hooks/useActiveSection.ts
@@ -1,7 +1,8 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { DEFAULT_SECTIONS, type SectionId } from "@/config/site";
+import { trackSectionView } from "@/utils/analytics";
 
 // Re-exported for backward compatibility — SectionId lives in @/config/site now.
 export type { SectionId };
@@ -10,6 +11,17 @@ export function useActiveSection(sectionIds: readonly string[] = DEFAULT_SECTION
   const [activeId, setActiveId] = useState<string>(sectionIds[0] ?? "");
 
   const ids = useMemo(() => [...sectionIds], [sectionIds]);
+
+  // Fire one view_section event per active section. Ref guards against
+  // re-firing the same section when the IntersectionObserver callback
+  // reports the same entry repeatedly.
+  const lastTrackedRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (activeId && activeId !== lastTrackedRef.current) {
+      lastTrackedRef.current = activeId;
+      trackSectionView(activeId);
+    }
+  }, [activeId]);
 
   useEffect(() => {
     const elements = ids


### PR DESCRIPTION
## Summary

- `trackSectionView()` was exported and unit-tested in `src/utils/analytics.ts` but never called from any component, leaving a dead API surface.
- Wire it into `useActiveSection` so a `view_section` GA event fires once per section transition (and once on the initial active section).
- A `useRef` guards against re-firing when the IntersectionObserver callback reports the same entry repeatedly.

## Changes

- `src/hooks/useActiveSection.ts` — import `trackSectionView`; add a ref-guarded `useEffect` keyed on `activeId`.
- `src/hooks/useActiveSection.test.ts` — mock `@next/third-parties/google`; add tests covering initial-section tracking, dedupe on repeat entries, and the empty-sections no-op.

## Verification

- `yarn test src/hooks/useActiveSection.test.ts` — 8/8 passing.
- `yarn test` — 160/160 unit tests passing. (`Contact.test.tsx` fails on `main` with the same pre-existing `resend` module resolution error; unrelated.)
- `yarn lint` — clean for changed files. (One pre-existing warning in `ContactForm.tsx`, unrelated.)
- `yarn type-check` — one pre-existing `resend` type declaration error in `src/app/actions/contact.ts`, unrelated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)