### PR TITLE
refactor: trivial cleanups (unused destructure, notFound guard, social links, contact tests)

### DIFF
--- a/src/app/actions/contact.test.ts
+++ b/src/app/actions/contact.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// `vi.mock` is hoisted above the imports, so the `send` function needs to
+// be hoisted via `vi.hoisted` so the mock factory can capture it.
+const sendMock = vi.hoisted(() => vi.fn());
+
+// Use a class so `new Resend(...)` returns an instance with stable identity
+// across invocations — and so the production code's chained access
+// (`resend.emails.send(...)`) consistently calls our shared spy.
+vi.mock("resend", () => ({
+  Resend: class {
+    emails = { send: sendMock };
+  },
+}));
+
+const { sendContactEmail } = await import("./contact");
+
+function makeFormData(
+  values: Partial<Record<"name" | "email" | "message", string>>,
+) {
+  const fd = new FormData();
+  if (values.name !== undefined) fd.append("name", values.name);
+  if (values.email !== undefined) fd.append("email", values.email);
+  if (values.message !== undefined) fd.append("message", values.message);
+  return fd;
+}
+
+describe("sendContactEmail", () => {
+  beforeEach(() => {
+    sendMock.mockReset();
+    // Silence "Resend error:" / "Error sending email:" output during test runs.
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("validation", () => {
+    it("returns an error when name is missing", async () => {
+      const result = await sendContactEmail(
+        makeFormData({ email: "a@b.com", message: "hi" }),
+      );
+      expect(result).toEqual({
+        success: false,
+        error: "All fields are required",
+      });
+      expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it("returns an error when email is missing", async () => {
+      const result = await sendContactEmail(
+        makeFormData({ name: "Marc", message: "hi" }),
+      );
+      expect(result).toEqual({
+        success: false,
+        error: "All fields are required",
+      });
+      expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it("returns an error when message is missing", async () => {
+      const result = await sendContactEmail(
+        makeFormData({ name: "Marc", email: "a@b.com" }),
+      );
+      expect(result).toEqual({
+        success: false,
+        error: "All fields are required",
+      });
+      expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it("returns an error when all fields are missing", async () => {
+      const result = await sendContactEmail(makeFormData({}));
+      expect(result).toEqual({
+        success: false,
+        error: "All fields are required",
+      });
+      expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it("returns an error when email is not in a valid format", async () => {
+      const result = await sendContactEmail(
+        makeFormData({ name: "Marc", email: "not-an-email", message: "hi" }),
+      );
+      expect(result).toEqual({
+        success: false,
+        error: "Invalid email address",
+      });
+      expect(sendMock).not.toHaveBeenCalled();
+    });
+
+    it("returns an error for emails missing a domain dot", async () => {
+      const result = await sendContactEmail(
+        makeFormData({ name: "Marc", email: "marc@example", message: "hi" }),
+      );
+      expect(result).toEqual({
+        success: false,
+        error: "Invalid email address",
+      });
+      expect(sendMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("Resend integration", () => {
+    it("sends the email and returns the data on success", async () => {
+      sendMock.mockResolvedValueOnce({ data: { id: "msg_123" }, error: null });
+
+      const result = await sendContactEmail(
+        makeFormData({
+          name: "Marc",
+          email: "marc@example.com",
+          message: "Hello\nWorld",
+        }),
+      );
+
+      expect(sendMock).toHaveBeenCalledTimes(1);
+      const payload = sendMock.mock.calls[0][0];
+      expect(payload.replyTo).toBe("marc@example.com");
+      expect(payload.subject).toBe("New contact form submission from Marc");
+      // HTML body should escape the newline as <br>.
+      expect(payload.html).toContain("Hello<br>World");
+      expect(result).toEqual({ success: true, data: { id: "msg_123" } });
+    });
+
+    it("falls back to onboarding@resend.dev from address when env is unset", async () => {
+      const previousFrom = process.env.RESEND_FROM_EMAIL;
+      delete process.env.RESEND_FROM_EMAIL;
+
+      sendMock.mockResolvedValueOnce({ data: { id: "msg_xyz" }, error: null });
+
+      try {
+        await sendContactEmail(
+          makeFormData({
+            name: "Marc",
+            email: "marc@example.com",
+            message: "hi",
+          }),
+        );
+
+        const payload = sendMock.mock.calls[0][0];
+        expect(payload.from).toBe("Contact Form <onboarding@resend.dev>");
+      } finally {
+        if (previousFrom !== undefined) {
+          process.env.RESEND_FROM_EMAIL = previousFrom;
+        }
+      }
+    });
+
+    it("returns a generic error when Resend reports a failure", async () => {
+      sendMock.mockResolvedValueOnce({
+        data: null,
+        error: { name: "validation_error", message: "bad recipient" },
+      });
+
+      const result = await sendContactEmail(
+        makeFormData({
+          name: "Marc",
+          email: "marc@example.com",
+          message: "hi",
+        }),
+      );
+
+      expect(sendMock).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({
+        success: false,
+        error: "Failed to send email. Please try again.",
+      });
+    });
+
+    it("catches and reports thrown errors from Resend", async () => {
+      sendMock.mockRejectedValueOnce(new Error("network down"));
+
+      const result = await sendContactEmail(
+        makeFormData({
+          name: "Marc",
+          email: "marc@example.com",
+          message: "hi",
+        }),
+      );
+
+      expect(sendMock).toHaveBeenCalledTimes(1);
+      expect(result).toEqual({
+        success: false,
+        error: "An unexpected error occurred. Please try again.",
+      });
+    });
+  });
+});

--- a/src/app/experience/[slug]/page.tsx
+++ b/src/app/experience/[slug]/page.tsx
@@ -75,66 +75,64 @@ export default async function ExperiencePage({ params }: ExperiencePageProps) {
 
   return (
     <div className="max-w-4xl mx-auto py-8">
-      {experience && ( // Conditionally render the script tag
-        <script
-          type="application/ld+json"
-          dangerouslySetInnerHTML={{
-            __html: JSON.stringify({
-              "@context": "https://schema.org",
-              "@graph": [
-                {
-                  "@type": "Article",
-                  headline: `${experience.title} at ${experience.company}`,
-                  description: experience.summary,
-                  author: {
-                    "@type": "Person",
-                    name: siteConfig.name,
-                    url: siteConfig.url,
-                  },
-                  publisher: {
-                    "@type": "Person",
-                    name: siteConfig.name,
-                    url: siteConfig.url,
-                  },
-                  mainEntityOfPage: {
-                    "@type": "WebPage",
-                    "@id": `${siteConfig.url}/experience/${slug}`,
-                  },
-                  about: {
-                    "@type": "Organization",
-                    name: experience.company,
-                    url: experience.companyUrl,
-                  },
-                  keywords: experience.skills.join(", "),
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{
+          __html: JSON.stringify({
+            "@context": "https://schema.org",
+            "@graph": [
+              {
+                "@type": "Article",
+                headline: `${experience.title} at ${experience.company}`,
+                description: experience.summary,
+                author: {
+                  "@type": "Person",
+                  name: siteConfig.name,
+                  url: siteConfig.url,
                 },
-                {
-                  "@type": "BreadcrumbList",
-                  itemListElement: [
-                    {
-                      "@type": "ListItem",
-                      position: 1,
-                      name: "Home",
-                      item: siteConfig.url,
-                    },
-                    {
-                      "@type": "ListItem",
-                      position: 2,
-                      name: "Experience",
-                      item: `${siteConfig.url}/#experience`,
-                    },
-                    {
-                      "@type": "ListItem",
-                      position: 3,
-                      name: `${experience.title} at ${experience.company}`,
-                      item: `${siteConfig.url}/experience/${slug}`,
-                    },
-                  ],
+                publisher: {
+                  "@type": "Person",
+                  name: siteConfig.name,
+                  url: siteConfig.url,
                 },
-              ],
-            }),
-          }}
-        />
-      )}
+                mainEntityOfPage: {
+                  "@type": "WebPage",
+                  "@id": `${siteConfig.url}/experience/${slug}`,
+                },
+                about: {
+                  "@type": "Organization",
+                  name: experience.company,
+                  url: experience.companyUrl,
+                },
+                keywords: experience.skills.join(", "),
+              },
+              {
+                "@type": "BreadcrumbList",
+                itemListElement: [
+                  {
+                    "@type": "ListItem",
+                    position: 1,
+                    name: "Home",
+                    item: siteConfig.url,
+                  },
+                  {
+                    "@type": "ListItem",
+                    position: 2,
+                    name: "Experience",
+                    item: `${siteConfig.url}/#experience`,
+                  },
+                  {
+                    "@type": "ListItem",
+                    position: 3,
+                    name: `${experience.title} at ${experience.company}`,
+                    item: `${siteConfig.url}/experience/${slug}`,
+                  },
+                ],
+              },
+            ],
+          }),
+        }}
+      />
       <Link
         href="/#experience"
         className="inline-flex items-center gap-2 text-[var(--accent)] hover:brightness-110 transition-all duration-200 font-medium text-sm mb-8 hover:gap-3"

--- a/src/components/Contact.tsx
+++ b/src/components/Contact.tsx
@@ -1,41 +1,13 @@
 "use client";
 
-import { siteConfig } from "@/config/site";
+import { socialLinks } from "@/config/site";
 import { trackSocialLink } from "@/utils/analytics";
 import { motion } from "framer-motion";
-import { FaGithub, FaInstagram, FaLinkedin, FaTwitter } from "react-icons/fa";
 import GlassCard from "./GlassCard";
 import SectionHeading from "./SectionHeading";
 import ContactForm from "./ContactForm";
 
 export default function Contact() {
-  const socialLinks = [
-    {
-      href: siteConfig.links.github,
-      icon: FaGithub,
-      label: "GitHub",
-      platform: "github" as const,
-    },
-    {
-      href: siteConfig.links.linkedin,
-      icon: FaLinkedin,
-      label: "LinkedIn",
-      platform: "linkedin" as const,
-    },
-    {
-      href: siteConfig.links.twitter,
-      icon: FaTwitter,
-      label: "Twitter",
-      platform: "twitter" as const,
-    },
-    {
-      href: siteConfig.links.instagram,
-      icon: FaInstagram,
-      label: "Instagram",
-      platform: "instagram" as const,
-    },
-  ];
-
   return (
     <motion.section
       id="contact"

--- a/src/components/ExperienceCard.tsx
+++ b/src/components/ExperienceCard.tsx
@@ -23,7 +23,6 @@ export const ExperienceCard: FC<ExperienceCardProps> = ({
   summary,
   skills,
   companyUrl,
-  isWeb3: _isWeb3,
   minimal = false,
 }) => {
   if (minimal) {

--- a/src/components/Menu.tsx
+++ b/src/components/Menu.tsx
@@ -1,9 +1,8 @@
 "use client";
 
-import { FaGithub, FaInstagram, FaLinkedin, FaTwitter } from "react-icons/fa";
 import { motion } from "framer-motion";
 import ThemeToggle from "./ThemeToggle";
-import { siteConfig, navItems } from "@/config/site";
+import { siteConfig, navItems, socialLinks } from "@/config/site";
 import { useActiveSection } from "@/hooks/useActiveSection";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
@@ -61,50 +60,23 @@ export default function Menu() {
           <div>
             <p className="text-xs uppercase tracking-widest text-slate-500 dark:text-grayTone/70 mb-2">On the web</p>
             <div className="flex items-center gap-2">
-              <a
-                href={siteConfig.links.github}
-                target="_blank"
-                rel="noopener noreferrer"
-                title="GitHub"
-                aria-label="GitHub"
-                onClick={() => trackSocialLink("github", siteConfig.links.github)}
-                className="h-9 w-9 inline-flex items-center justify-center rounded-md border border-black/10 dark:border-white/10 bg-white/60 dark:bg-white/5 text-slate-600 dark:text-grayTone hover:text-[var(--accent)] hover:border-[var(--accent)] transition-colors"
-              >
-                <FaGithub size={18} />
-              </a>
-              <a
-                href={siteConfig.links.linkedin}
-                target="_blank"
-                rel="noopener noreferrer"
-                title="LinkedIn"
-                aria-label="LinkedIn"
-                onClick={() => trackSocialLink("linkedin", siteConfig.links.linkedin)}
-                className="h-9 w-9 inline-flex items-center justify-center rounded-md border border-black/10 dark:border-white/10 bg-white/60 dark:bg-white/5 text-slate-600 dark:text-grayTone hover:text-[var(--accent)] hover:border-[var(--accent)] transition-colors"
-              >
-                <FaLinkedin size={18} />
-              </a>
-              <a
-                href={siteConfig.links.twitter}
-                target="_blank"
-                rel="noopener noreferrer"
-                title="Twitter/X"
-                aria-label="Twitter"
-                onClick={() => trackSocialLink("twitter", siteConfig.links.twitter)}
-                className="h-9 w-9 inline-flex items-center justify-center rounded-md border border-black/10 dark:border-white/10 bg-white/60 dark:bg-white/5 text-slate-600 dark:text-grayTone hover:text-[var(--accent)] hover:border-[var(--accent)] transition-colors"
-              >
-                <FaTwitter size={18} />
-              </a>
-              <a
-                href={siteConfig.links.instagram}
-                target="_blank"
-                rel="noopener noreferrer"
-                title="Instagram"
-                aria-label="Instagram"
-                onClick={() => trackSocialLink("instagram", siteConfig.links.instagram)}
-                className="h-9 w-9 inline-flex items-center justify-center rounded-md border border-black/10 dark:border-white/10 bg-white/60 dark:bg-white/5 text-slate-600 dark:text-grayTone hover:text-[var(--accent)] hover:border-[var(--accent)] transition-colors"
-              >
-                <FaInstagram size={18} />
-              </a>
+              {socialLinks.map((link) => {
+                const Icon = link.icon;
+                return (
+                  <a
+                    key={link.platform}
+                    href={link.href}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    title={link.title}
+                    aria-label={link.label}
+                    onClick={() => trackSocialLink(link.platform, link.href)}
+                    className="h-9 w-9 inline-flex items-center justify-center rounded-md border border-black/10 dark:border-white/10 bg-white/60 dark:bg-white/5 text-slate-600 dark:text-grayTone hover:text-[var(--accent)] hover:border-[var(--accent)] transition-colors"
+                  >
+                    <Icon size={18} />
+                  </a>
+                );
+              })}
             </div>
           </div>
         </div>

--- a/src/config/site.ts
+++ b/src/config/site.ts
@@ -1,3 +1,11 @@
+import { type IconType } from "react-icons";
+import {
+  FaGithub,
+  FaInstagram,
+  FaLinkedin,
+  FaTwitter,
+} from "react-icons/fa";
+
 export const ogImageSize = {
   width: 1200,
   height: 630,
@@ -48,3 +56,43 @@ export const siteConfig = {
 };
 
 export type SiteConfig = typeof siteConfig;
+
+// Single source of truth for social platforms (consumed by Menu and Contact).
+export const socialLinks = [
+  {
+    platform: "github",
+    href: siteConfig.links.github,
+    label: "GitHub",
+    title: "GitHub",
+    icon: FaGithub,
+  },
+  {
+    platform: "linkedin",
+    href: siteConfig.links.linkedin,
+    label: "LinkedIn",
+    title: "LinkedIn",
+    icon: FaLinkedin,
+  },
+  {
+    platform: "twitter",
+    href: siteConfig.links.twitter,
+    label: "Twitter",
+    title: "Twitter/X",
+    icon: FaTwitter,
+  },
+  {
+    platform: "instagram",
+    href: siteConfig.links.instagram,
+    label: "Instagram",
+    title: "Instagram",
+    icon: FaInstagram,
+  },
+] as const satisfies ReadonlyArray<{
+  platform: string;
+  href: string;
+  label: string;
+  title: string;
+  icon: IconType;
+}>;
+
+export type SocialPlatform = (typeof socialLinks)[number]["platform"];


### PR DESCRIPTION
Three small cleanups around code touched during recent refactors:

- **ExperienceCard.tsx**: drop the `isWeb3: _isWeb3` destructure — the prop is never read here.
- **experience/[slug]/page.tsx**: remove the `experience &&` guard around the JSON-LD `<script>`. After `notFound()` (typed `never`) the variable is already non-null.
- **site.ts / Menu.tsx / Contact.tsx**: replace the two inline four-platform social lists with a single `socialLinks` export in `site.ts` (platform, href, label, title, icon). Both consumers map over it.
- **actions/contact.ts**: new `*.test.ts` covering field-required validation, email-regex rejection, the success path (payload shape, line-break escaping, default `from`), Resend `{ error }`, and Resend throwing.

Tests: `yarn test` → 42 files, 174 tests, all green.