### PR TITLE
Add Antler Labs Principal Product Engineer experience

### DIFF
--- a/src/config/experience.ts
+++ b/src/config/experience.ts
@@ -22,6 +22,36 @@ export interface ExperienceData {
 
 export const experiences: ExperienceData[] = [
   {
+    slug: "antler-labs",
+    title: "Principal Product Engineer",
+    company: "Antler Labs",
+    location: "Remote",
+    type: "remote",
+    startDate: "Jun 2025",
+    endDate: "Present",
+    updatedAt: "2026-08",
+    summary:
+      "Architect and build production software across AI, developer tooling, infrastructure, and blockchain systems.",
+    description:
+      "Own end-to-end product development at Antler Labs, from product definition and technical architecture through implementation, deployment, and iteration. Build multiple independent products spanning AI, developer tooling, infrastructure, and blockchain systems.",
+    highlights: [
+      "Architect and build production software across AI, developer tooling, infrastructure, and blockchain systems",
+      "Own end-to-end product development, from product definition and technical architecture through implementation, deployment, and iteration",
+      "Built multiple independent products using TypeScript, Next.js, Node.js, PostgreSQL, Solidity, and modern cloud infrastructure",
+    ],
+    skills: [
+      "TypeScript",
+      "Next.js",
+      "Node.js",
+      "PostgreSQL",
+      "Solidity",
+      "AI",
+      "Cloud Infrastructure",
+      "Developer Tooling",
+    ],
+    isWeb3: true,
+  },
+  {
     slug: "autonomys",
     title: "Lead Software Engineer",
     company: "Autonomys Network",


### PR DESCRIPTION
## Summary
- Add current Antler Labs role (Principal Product Engineer, Jun 2025–Present) to match LinkedIn
- Place it first in the experience list so homepage, listing, detail pages, and sitemap pick it up

## Test plan
- [ ] Confirm Experience section shows Antler Labs as the top/current role
- [ ] Visit `/experience/antler-labs` and verify title, dates, highlights, and skills
- [ ] Confirm Autonomys and older roles still render correctly after it


Made with [Cursor](https://cursor.com)